### PR TITLE
Minor bug in sample

### DIFF
--- a/data_hacks/sample.py
+++ b/data_hacks/sample.py
@@ -31,11 +31,11 @@ def run(sample_rate):
         line = input_stream.readline()
         if not line:
             break
-        if random.randint(1,100) < sample_rate:
+        if random.randint(1,100) <= sample_rate:
             sys.stdout.write(line)
 
 def get_sample_rate(rate_string):
-    """ return a rate as a percewntage"""
+    """ return a rate as a percentage"""
     if rate_string.endswith("%"):
         rate = int(rate_string[:-1])
     elif '/' in rate_string:


### PR DESCRIPTION
Hi, I was using the sample script to reduce a 6.5 million line data trace (since histogram is very slow with that many lines) and tried 1% for the sample amount.  It didn't work.  Looked at the script and found that `random.randint(1, 100) < sample_rate` would never be true with the sample_rate == 1, so I fixed it.

And a typo.

Thanks for making these scripts!
