### PR TITLE
Added options for key width, chart width, and key justification.

### DIFF
--- a/data_hacks/bar_chart.py
+++ b/data_hacks/bar_chart.py
@@ -46,8 +46,9 @@ def run(input_stream, options):
     
     max_length = max([len(key) for key in data.keys()])
     max_length = min(max_length, options.key_length)
-    value_characters = options.width - max_length - 10 # ' [%6d] '
     max_value = max(data.values())
+    max_value_length = len(str(max_value))
+    value_characters = options.width - max_length - max_value_length
     scale = int(math.ceil(float(max_value) / value_characters))
     scale = max(1, scale)
     
@@ -65,7 +66,8 @@ def run(input_stream, options):
         data.sort(reverse=options.reverse_sort)
         data = [[value, key] for key,value in data]
     justification = "-" if options.justification == "left" else ""
-    format = "%" + justification + str(max_length) + "s [%6d] %s"
+    format = ("%" + justification + str(max_length) + "s [%" +
+              str(max_value_length) + "d] %s")
     for value,key in data:
         print format % (key[:max_length], value, (value / scale) * "*")
 


### PR DESCRIPTION
```
$ bar_chart.py --help
Usage: cat data | bar_chart.py [options]

Options:
  -h, --help            show this help message and exit
  -k, --sort-keys       sort by the key [default]
  -v, --sort-values     sort by the frequence
  -r, --reverse-sort    reverse the sort
  -j JUSTIFICATION, --justification=JUSTIFICATION
                        output justification of keys [right]
  -l KEY_LENGTH, --key-length=KEY_LENGTH
                        output length of keys [50]
  -w WIDTH, --width=WIDTH
                        output width of chart [80]
```
