### PR TITLE
Tolerate delimiters wider than 1 space.

### DIFF
--- a/data_hacks/bar_chart.py
+++ b/data_hacks/bar_chart.py
@@ -19,8 +19,9 @@ Generate an ascii bar chart for input data
 
 http://github.com/bitly/data_hacks
 """
-import sys
 import math
+import re
+import sys
 from collections import defaultdict
 from optparse import OptionParser
 from decimal import Decimal
@@ -37,10 +38,11 @@ def load_stream(input_stream):
             yield clean_line
 
 def run(input_stream, options):
+    p = re.compile(' +')
     data = defaultdict(lambda:0)
     for row in input_stream:
         if options.agg_values:
-            kv = row.split(' ',2);
+            kv = p.split(row, 2);
             data[kv[0]]+= int(kv[1])
         else:
             data[row]+=1


### PR DESCRIPTION
This prevents cashes on wide delimiters:

    $ ./bar_chart.py -a << EOF
    1   1
    EOF
    Traceback (most recent call last):
      File "./bar_chart.py", line 101, in <module>
        run(load_stream(sys.stdin), options)
      File "./bar_chart.py", line 48, in run
        data[kv[0]]+= int(kv[1])
    ValueError: invalid literal for int() with base 10: ''